### PR TITLE
Add binary distribution

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,23 @@ builds:
       - amd64
       - 386
 
+brews:
+  - name: vega
+    github:
+      owner: srijanone
+      name: homebrew-vega
+    url_template: "https://github.com/srijanone/vega/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: Vijay Soni (vs4vijay)
+      email: vs4vijay@gmail.com
+    folder: Formula
+    description: "vega"
+    skip_upload: false
+    install: |
+      bin.install "vega"
+    test: |
+      system "#{bin}/vega version"
+
 archives:
   - replacements:
       darwin: mac

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,41 @@
+before:
+  hooks:
+    - go mod download
+
+dist: bin
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X=github.com/srijanone/vega/pkg/version.SemVer={{ .Version }}
+      - -X=github.com/srijanone/vega/pkg/version.GitCommit={{ .Commit }}
+      - -X=github.com/srijanone/vega/pkg/version.BuildTime={{ .Date }}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+
+archives:
+  - replacements:
+      darwin: mac
+      linux: linux
+      windows: windows
+      386: i386
+      amd64: x86_64
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,24 @@ brews:
     test: |
       system "#{bin}/vega version"
 
+nfpms:
+  - file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    homepage:  https://github.com/srijanone/vega
+    description: "vega"
+    maintainer: Vijay Soni <vs4vijay@gmail.com>
+    license: MIT
+    formats:
+      - deb
+      - rpm
+
+#snapcrafts:
+#  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+#    summary: "vega"
+#    description: "vega"
+#    grade: stable
+#    confinement: classic
+#    publish: true
+
 archives:
   - replacements:
       darwin: mac

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PROJECT := "vega"
 
-
 GIT_COMMIT 	:= `git rev-parse HEAD`
 GIT_SHA 	:= `git rev-parse --short HEAD`
 GIT_TAG 	:= `git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo "canary"`
@@ -12,12 +11,24 @@ LDFLAGS += -X=github.com/srijanone/vega/pkg/version.GitCommit=$(GIT_COMMIT)
 LDFLAGS += -X=github.com/srijanone/vega/pkg/version.BuildTime=$(BUILD_TIME)
 
 OS 			:= `uname | tr '[:upper:]' '[:lower:]'`
-ARCH 		:= `uname -m`
+OS_LIST		:= darwin linux windows
 
+ARCH 		:= `uname -m`
+ARCH_LIST	:= 386 amd64
 
 .PHONY: info
 info:
 	@echo "info..."
+	@echo "Version:       		${GIT_TAG}"
+	@echo "Git Commit:       	${GIT_COMMIT}"
+	@echo "Git SHA:       		${GIT_SHA}"
+	@echo "Build Time:       	${BUILD_TIME}"
+	@echo ""
+
+
+.PHONY: fmt
+fmt:
+	gofmt -l -w .
 
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,17 @@ build: info
 	GOOS=darwin GOARCH=386 go build -v -ldflags "$(LDFLAGS)"
 
 
+.PHONY: build-all
+build-all:
+	@for os in ${OS_LIST}; do \
+		for arch in ${ARCH_LIST}; do \
+			echo "Building for OS($${os}) and Arch($${arch})"; \
+			GOOS=$${os} GOARCH=$${arch} go build -v -ldflags "$(LDFLAGS)" -o "bin/vizix_$${os}_$${arch}"; \
+		done \
+	done
+
+
 .PHONY: clean
 clean:
 	@echo "cleaning..."
-	rm -rf ~/.vega
+	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
-PROJECT = "vega"
+PROJECT := "vega"
 
-.PHONY: info clean
 
+
+
+
+.PHONY: info
 info:
 	@echo "info..."
 
+
+.PHONY: build
+build: info
+	go build -v
+
+
+.PHONY: clean
 clean:
+	@echo "cleaning..."
 	rm -rf ~/.vega

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PROJECT := "vega"
 
 
+GIT_COMMIT 	:= `git rev-parse HEAD`
+GIT_SHA 	:= `git rev-parse --short HEAD`
+GIT_TAG 	:= `git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo "canary"`
+BUILD_TIME  := `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ LDFLAGS += -X=github.com/srijanone/vega/pkg/version.SemVer=$(GIT_TAG)
 LDFLAGS += -X=github.com/srijanone/vega/pkg/version.GitCommit=$(GIT_COMMIT)
 LDFLAGS += -X=github.com/srijanone/vega/pkg/version.BuildTime=$(BUILD_TIME)
 
+OS 			:= `uname | tr '[:upper:]' '[:lower:]'`
+ARCH 		:= `uname -m`
+
 
 .PHONY: info
 info:
@@ -19,7 +22,7 @@ info:
 
 .PHONY: build
 build: info
-	go build -v
+	GOOS=darwin GOARCH=386 go build -v -ldflags "$(LDFLAGS)"
 
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ GIT_SHA 	:= `git rev-parse --short HEAD`
 GIT_TAG 	:= `git describe --tags --abbrev=0 --exact-match 2>/dev/null || echo "canary"`
 BUILD_TIME  := `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
+LDFLAGS := ""
+LDFLAGS += -X=github.com/srijanone/vega/pkg/version.SemVer=$(GIT_TAG)
+LDFLAGS += -X=github.com/srijanone/vega/pkg/version.GitCommit=$(GIT_COMMIT)
+LDFLAGS += -X=github.com/srijanone/vega/pkg/version.BuildTime=$(BUILD_TIME)
 
 
 .PHONY: info

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Via **Homebrew** (Mac only):
 brew install srijanone/vega/vega
 ```
 
-Get **\*.deb and \*.rpm files**:
-- (releases)[https://github.com/srijanone/vega/releases]
+Via **\*.deb and \*.rpm files**:
+- [releases](https://github.com/srijanone/vega/releases)
 
-Get prebuilt binaries:
-- (releases)[https://github.com/srijanone/vega/releases]
+Via prebuilt binaries:
+- [releases](https://github.com/srijanone/vega/releases)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Via **Go Get**:
 ```
 go get github.com/srijanone/vega
 ```
+
+Via **Homebrew** (Mac only):
+
+```
+brew install srijanone/vega/vega
+```
+
+Get **\*.deb and \*.rpm files**:
+- (releases)[https://github.com/srijanone/vega/releases]
+
+Get prebuilt binaries:
+- (releases)[https://github.com/srijanone/vega/releases]
+
 ---
 
 ## Getting Started
@@ -26,6 +39,8 @@ vega down
 ## Development
 
 `go run main.go`
+
+- For Releasing: `goreleaser`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,21 +34,23 @@ vega create --starterkit <starterkit>
 vega up
 vega down
 ```
+
 ---
 
 ## Development
 
 `go run main.go`
 
-- For Releasing: `goreleaser`
+- For Releasing Binaries: `goreleaser`
 
 ---
 
 ## To Do
 
 - [x] Basic Functionality
+- [x] Release Binaries
 - [ ] Dockerize
-- [ ] Makefile
+- [x] Makefile
   - run
   - test
   - clean

--- a/pkg/tilt/tilt.go
+++ b/pkg/tilt/tilt.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	commandName = "tilt"
+	commandName  = "tilt"
 	RequiredText = `
 		Tilt is not installed, which is required to run the application. 
 	`
@@ -23,17 +23,17 @@ func IsInstalled() bool {
 	return err == nil
 }
 
-func Up(out io.Writer, arguments... string)  {
+func Up(out io.Writer, arguments ...string) {
 	arguments = append([]string{"up"}, arguments...)
 	execute(out, arguments...)
 }
 
-func Down(out io.Writer, arguments... string)  {
+func Down(out io.Writer, arguments ...string) {
 	arguments = append([]string{"down"}, arguments...)
 	execute(out, arguments...)
 }
 
-func execute(out io.Writer, arguments... string)  {
+func execute(out io.Writer, arguments ...string) {
 	command := exec.Command(commandName, arguments...)
 	command.Stdout = out
 	command.Stderr = os.Stderr

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,40 +3,37 @@ package version
 import "fmt"
 
 type Version struct {
-	SemVer       string `json:"semver"`
-	GitCommit    string `json:"git-commit"`
-	GitTreeState string `json:"git-tree-state"`
+	Version   string `json:"version"`
+	GitCommit string `json:"git-commit"`
 }
 
 func (v *Version) String() string {
-	return v.SemVer
+	return v.Version
 }
 
 func (v *Version) FormatVersion(short bool) string {
 	if short {
-		return fmt.Sprintf("%s+%s", v.SemVer, v.GitCommit[:7])
+		return fmt.Sprintf("%s+%s", v.Version, v.GitCommit[:7])
 	}
 	return fmt.Sprintf("%#v", v)
 }
 
 var (
-	Release       = "canary"
-	BuildMetadata = ""
-	GitCommit     = ""
-	GitTreeState  = ""
+	SemVer    = "canary"
+	GitCommit = ""
+	BuildTime = ""
 )
 
 func getVersion() string {
-	if BuildMetadata == "" {
-		return Release
+	if BuildTime == "" {
+		return SemVer
 	}
-	return Release + "+" + BuildMetadata
+	return fmt.Sprintf("%s+%s", SemVer, BuildTime)
 }
 
 func New() *Version {
 	return &Version{
-		SemVer:       getVersion(),
-		GitCommit:    GitCommit,
-		GitTreeState: GitTreeState,
+		Version:   getVersion(),
+		GitCommit: GitCommit,
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,7 @@ func (v *Version) String() string {
 
 func (v *Version) FormatVersion(short bool) string {
 	if short {
-		return fmt.Sprintf("%s+g%s", v.SemVer, v.GitCommit[:7])
+		return fmt.Sprintf("%s+%s", v.SemVer, v.GitCommit[:7])
 	}
 	return fmt.Sprintf("%#v", v)
 }


### PR DESCRIPTION
PR Contains following functionalities:

- Binary build for **MacOS, Linux and Windows** (Check the release page)
- Supports both **32-bit** and **64-bit** architectures
- Automatically tagging and release the binary from local machine
- Pushes binary to homebrew as well: https://github.com/srijanone/homebrew-vega
- `brew install srijanone/vega/vega` will work once we made this repo. public

PS: Used an awesome tool called `goreleaser`